### PR TITLE
Accelerate with copilot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -106,3 +106,19 @@ def signup_for_activity(activity_name: str, email: str):
         raise HTTPException(status_code=400, detail="Student is already signed up for this activity")
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/unregister")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
+
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,45 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    # Sports activities
+    "Basketball Team": {
+        "description": "Competitive basketball team with games and practices",
+        "schedule": "Mondays, Wednesdays, Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 15,
+        "participants": ["marcus@mergington.edu"]
+    },
+    "Tennis Club": {
+        "description": "Learn tennis skills and compete in matches",
+        "schedule": "Tuesdays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 20,
+        "participants": ["alex@mergington.edu"]
+    },
+    # Artistic activities
+    "Drama Club": {
+        "description": "Act in school plays and musical performances",
+        "schedule": "Wednesdays, 4:00 PM - 6:00 PM",
+        "max_participants": 25,
+        "participants": ["isabella@mergington.edu", "james@mergington.edu"]
+    },
+    "Art Studio": {
+        "description": "Painting, drawing, and sculpture techniques",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["grace@mergington.edu"]
+    },
+    # Intellectual activities
+    "Debate Team": {
+        "description": "Develop public speaking and arguing skills through competitions",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 16,
+        "participants": ["ryan@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Explore scientific concepts through experiments and projects",
+        "schedule": "Tuesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 24,
+        "participants": ["noah@mergington.edu", "ava@mergington.edu"]
     }
 }
 
@@ -63,5 +102,7 @@ def signup_for_activity(activity_name: str, email: str):
     activity = activities[activity_name]
 
     # Add student
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is already signed up for this activity")
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -20,11 +20,37 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        const participantsMarkup = details.participants.length
+          ? `<ul class="participants-list">
+              ${details.participants
+                .map(
+                  (email) =>
+                    `<li>
+                      <span class="participant-avatar">${email.charAt(0).toUpperCase()}</span>
+                      <span class="participant-email">${email}</span>
+                      <button
+                        type="button"
+                        class="participant-delete"
+                        title="Unregister ${email}"
+                        aria-label="Unregister ${email}"
+                        data-activity="${encodeURIComponent(name)}"
+                        data-email="${encodeURIComponent(email)}"
+                      >&times;</button>
+                    </li>`
+                )
+                .join("")}
+            </ul>`
+          : `<p class="participants-empty">No participants yet — be the first to join!</p>`;
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <h5>Participants (${details.participants.length}/${details.max_participants})</h5>
+            ${participantsMarkup}
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -40,6 +66,45 @@ document.addEventListener("DOMContentLoaded", () => {
       console.error("Error fetching activities:", error);
     }
   }
+
+  // Handle unregister button clicks (event delegation)
+  activitiesList.addEventListener("click", async (event) => {
+    const button = event.target.closest(".participant-delete");
+    if (!button) return;
+
+    const activity = decodeURIComponent(button.dataset.activity);
+    const email = decodeURIComponent(button.dataset.email);
+
+    if (!confirm(`Unregister ${email} from ${activity}?`)) return;
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/unregister?email=${encodeURIComponent(email)}`,
+        { method: "DELETE" }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        // Refresh the activities list to reflect the change
+        activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
+        await fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "An error occurred";
+        messageDiv.className = "error";
+      }
+
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => messageDiv.classList.add("hidden"), 5000);
+    } catch (error) {
+      messageDiv.textContent = "Failed to unregister. Please try again.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      console.error("Error unregistering:", error);
+    }
+  });
 
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,100 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px dashed #cfd8dc;
+}
+
+.participants-section h5 {
+  margin-bottom: 10px;
+  color: #1a237e;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.participants-list {
+  list-style: none;
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.participants-list li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  background-color: #ffffff;
+  border: 1px solid #e0e0e0;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  color: #37474f;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.participants-list li::marker {
+  content: "";
+}
+
+.participant-delete {
+  background: transparent;
+  border: none;
+  color: #b0bec5;
+  font-size: 1.2rem;
+  line-height: 1;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border-radius: 50%;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.15s ease, color 0.15s ease, transform 0.15s ease;
+}
+
+.participant-delete:hover {
+  background-color: #ffebee;
+  color: #c62828;
+  transform: scale(1.1);
+}
+
+.participants-list li:hover {
+  transform: translateX(2px);
+  box-shadow: 0 2px 6px rgba(26, 35, 126, 0.12);
+}
+
+.participant-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #1a237e, #3949ab);
+  color: #fff;
+  font-weight: bold;
+  font-size: 0.8rem;
+  flex-shrink: 0;
+}
+
+.participant-email {
+  word-break: break-all;
+  flex: 1;
+}
+
+.participants-empty {
+  font-style: italic;
+  color: #78909c;
+  font-size: 0.9rem;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,139 @@
+import copy
+import pytest
+from fastapi.testclient import TestClient
+
+import src.app as app_module
+from src.app import app
+
+client = TestClient(app, follow_redirects=False)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    """Restore the module-level activities dict after every test so mutations
+    made by one test never bleed into another."""
+    original = copy.deepcopy(app_module.activities)
+    yield
+    app_module.activities.clear()
+    app_module.activities.update(original)
+
+
+# ---------------------------------------------------------------------------
+# GET /
+# ---------------------------------------------------------------------------
+
+def test_root_redirects():
+    response = client.get("/")
+    assert response.status_code in (301, 302, 303, 307, 308)
+    assert "/static/index.html" in response.headers["location"]
+
+
+# ---------------------------------------------------------------------------
+# GET /activities
+# ---------------------------------------------------------------------------
+
+def test_get_activities_returns_all():
+    response = client.get("/activities")
+    assert response.status_code == 200
+    data = response.json()
+    expected_activities = [
+        "Chess Club",
+        "Programming Class",
+        "Gym Class",
+        "Basketball Team",
+        "Tennis Club",
+        "Drama Club",
+        "Art Studio",
+        "Debate Team",
+        "Science Club",
+    ]
+    for name in expected_activities:
+        assert name in data, f"Activity '{name}' missing from response"
+
+
+def test_get_activities_structure():
+    response = client.get("/activities")
+    assert response.status_code == 200
+    data = response.json()
+    required_fields = {"description", "schedule", "max_participants", "participants"}
+    for name, details in data.items():
+        for field in required_fields:
+            assert field in details, f"Activity '{name}' missing field '{field}'"
+        assert isinstance(details["participants"], list)
+        assert isinstance(details["max_participants"], int)
+
+
+# ---------------------------------------------------------------------------
+# POST /activities/{activity_name}/signup
+# ---------------------------------------------------------------------------
+
+def test_signup_success():
+    response = client.post(
+        "/activities/Chess Club/signup",
+        params={"email": "newstudent@mergington.edu"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "message" in body
+    assert "newstudent@mergington.edu" in body["message"]
+    # Verify the participant was actually added
+    assert "newstudent@mergington.edu" in app_module.activities["Chess Club"]["participants"]
+
+
+def test_signup_already_registered():
+    # "michael@mergington.edu" is pre-seeded in Chess Club
+    response = client.post(
+        "/activities/Chess Club/signup",
+        params={"email": "michael@mergington.edu"},
+    )
+    assert response.status_code == 400
+    assert "already signed up" in response.json()["detail"].lower()
+
+
+def test_signup_unknown_activity():
+    response = client.post(
+        "/activities/Underwater Basket Weaving/signup",
+        params={"email": "someone@mergington.edu"},
+    )
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# DELETE /activities/{activity_name}/unregister
+# ---------------------------------------------------------------------------
+
+def test_unregister_success():
+    # "michael@mergington.edu" is pre-seeded in Chess Club
+    response = client.delete(
+        "/activities/Chess Club/unregister",
+        params={"email": "michael@mergington.edu"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "message" in body
+    assert "michael@mergington.edu" in body["message"]
+    # Verify participant was actually removed
+    assert "michael@mergington.edu" not in app_module.activities["Chess Club"]["participants"]
+
+
+def test_unregister_not_registered():
+    response = client.delete(
+        "/activities/Chess Club/unregister",
+        params={"email": "ghost@mergington.edu"},
+    )
+    assert response.status_code == 400
+    assert "not signed up" in response.json()["detail"].lower()
+
+
+def test_unregister_unknown_activity():
+    response = client.delete(
+        "/activities/Underwater Basket Weaving/unregister",
+        params={"email": "someone@mergington.edu"},
+    )
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()


### PR DESCRIPTION
This pull request adds the ability for users to unregister from activities, enhances the frontend to display and manage participants for each activity, introduces new activity types, and adds comprehensive backend tests. These changes improve both the user experience and code reliability.

**Backend functionality:**

* Added a new `unregister_from_activity` endpoint (`DELETE /activities/{activity_name}/unregister`) to allow students to remove themselves from activities, with appropriate error handling if the student is not registered or the activity does not exist.
* Updated the signup logic to prevent duplicate registrations by returning an error if a student is already signed up.

**Frontend improvements:**

* Enhanced the activity cards to display a list of current participants, each with an avatar, email, and an "unregister" button; added logic to handle unregistering via the new backend endpoint and refresh the UI accordingly. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R23-R53) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R70-R108)
* Added new CSS styles for the participants section, including avatars, participant list styling, and unregister button hover effects.

**Data and testing:**

* Added several new activities (sports, artistic, and intellectual) to the activities data structure, each with their own schedule and participants.
* Introduced a new test suite (`tests/test_app.py`) that covers all core API endpoints, including signup and unregister flows, with fixtures to ensure test isolation.